### PR TITLE
Refactor: Autoformatted every Java file and auto organized imports

### DIFF
--- a/src/main/java/cmpt276/pg6/realtorest/controllers/MainController.java
+++ b/src/main/java/cmpt276/pg6/realtorest/controllers/MainController.java
@@ -19,8 +19,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
-
-
 @Controller
 public class MainController {
     @Autowired
@@ -40,8 +38,6 @@ public class MainController {
     }
 
     // #endregion
-
-
 
     // #region Visitable Pages
 
@@ -110,8 +106,6 @@ public class MainController {
     }
 
     // #endregion
-
-
 
     // #region Post mappings
 
@@ -246,11 +240,7 @@ public class MainController {
         return new RedirectView("");
     }
 
-
-
     // #endregion
-
-
 
     // #region Redirects
 

--- a/src/main/java/cmpt276/pg6/realtorest/models/UserRepository.java
+++ b/src/main/java/cmpt276/pg6/realtorest/models/UserRepository.java
@@ -3,7 +3,6 @@ package cmpt276.pg6.realtorest.models;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-
 public interface UserRepository extends JpaRepository<User, Integer> {
     List<User> findByEmailAndPassword(String email, String password);
 }

--- a/src/test/java/cmpt276/pg6/realtorest/RealtorestApplicationTests.java
+++ b/src/test/java/cmpt276/pg6/realtorest/RealtorestApplicationTests.java
@@ -2,7 +2,6 @@ package cmpt276.pg6.realtorest;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.SpringApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import io.github.cdimascio.dotenv.Dotenv;
 

--- a/src/test/java/cmpt276/pg6/realtorest/controllers/MainControllerTest.java
+++ b/src/test/java/cmpt276/pg6/realtorest/controllers/MainControllerTest.java
@@ -30,6 +30,8 @@ public class MainControllerTest {
 
     @Test
     void testShowHomePage() throws Exception {
-        this.mockMvc.perform(MockMvcRequestBuilders.get("/")).andExpect(MockMvcResultMatchers.status().isOk()).andExpect(MockMvcResultMatchers.view().name("home"));
+        this.mockMvc.perform(MockMvcRequestBuilders.get("/"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.view().name("home"));
     }
 }


### PR DESCRIPTION
Ok, I will admit that this is probably unnecessary and could cause more troubles with merge conflicts. And it can also make marking stuff hard, because when you `git blame`, all you see is Kevin auto formatting everything.

But in my defense, this project is too small to setup a linting system and get the auto formatters on everyone's setup to behave the same way. And I know this is Kevin being weird, but I just really can't code if my auto formatter and auto completion isn't working.

If this is a big project and there are formatting and linting rules, I can obey them. But since this is a small project... I just have to format the entire codebase in a consistent way.

Sorry for all the incontinences.