### PR TITLE
Logout navigation

### DIFF
--- a/src/main/java/cmpt276/pg6/realtorest/controllers/FavouriteController.java
+++ b/src/main/java/cmpt276/pg6/realtorest/controllers/FavouriteController.java
@@ -57,7 +57,7 @@ public class FavouriteController {
                 return "favourites";
             }
         }
-        return "login";
+        return "redirect:/login";
     }
 
     //Add property to favourites

--- a/src/main/java/cmpt276/pg6/realtorest/controllers/FavouriteController.java
+++ b/src/main/java/cmpt276/pg6/realtorest/controllers/FavouriteController.java
@@ -16,6 +16,7 @@ import cmpt276.pg6.realtorest.models.PropertyRepository;
 import cmpt276.pg6.realtorest.models.User;
 import cmpt276.pg6.realtorest.models.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
 @Controller
@@ -43,7 +44,13 @@ public class FavouriteController {
     }
 
     @GetMapping("/favourites")
-    public String showFavouritesPage(HttpServletRequest request, HttpSession session, Model model) {
+    public String showFavouritesPage(HttpServletRequest request, HttpSession session, Model model,
+        HttpServletResponse response) {
+        // Set no-cache headers
+        response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate"); // HTTP 1.1.
+        response.setHeader("Pragma", "no-cache"); // HTTP 1.0.
+        response.setDateHeader("Expires", 0); // Proxies.
+
         User sessionUser = (User) session.getAttribute("session_user");
         Integer userId = sessionUser != null ? sessionUser.getUid() : null;
 

--- a/src/main/java/cmpt276/pg6/realtorest/controllers/UserController.java
+++ b/src/main/java/cmpt276/pg6/realtorest/controllers/UserController.java
@@ -158,8 +158,13 @@ public class UserController {
     // Logout by nuking the session
     // TODO: Would it be better to use a POST request for this?
     @GetMapping("/logout")
-    public String destroySession(HttpServletRequest request) {
+    public String destroySession(HttpServletRequest request, HttpServletResponse response) {
         request.getSession().invalidate();
+        //no-cache headers to ensure the final page isn't cached by the browser
+        response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate"); // HTTP 1.1
+        response.setHeader("Pragma", "no-cache"); // HTTP 1.0
+        response.setDateHeader("Expires", 0); // Proxies
+
         return "redirect:/";
     }
 

--- a/src/main/resources/templates/favourites.html
+++ b/src/main/resources/templates/favourites.html
@@ -140,6 +140,12 @@
         </section>
 
         <script>
+            document.addEventListener("DOMContentLoaded", function() {
+                if (!sessionStorage.getItem("isLoggedIn")) {
+                    window.location.href = "/login";
+                }
+            });
+            
             function toggleFavourite(button) {
                 var propertyId = button.getAttribute("data-pid")
                 var iconElement = button.querySelector("i")

--- a/src/main/resources/templates/favourites.html
+++ b/src/main/resources/templates/favourites.html
@@ -140,12 +140,6 @@
         </section>
 
         <script>
-            document.addEventListener("DOMContentLoaded", function() {
-                if (!sessionStorage.getItem("isLoggedIn")) {
-                    window.location.href = "/login";
-                }
-            });
-            
             function toggleFavourite(button) {
                 var propertyId = button.getAttribute("data-pid")
                 var iconElement = button.querySelector("i")


### PR DESCRIPTION
Fixed the issue where navigating back after logging out would redirect the user to a protected favourites page. Now, users are directed to the homepage following logout, and access to protected pages is revoked as the session ends.