### PR TITLE
Changed British spelling of favourite into American spelling favorite

### DIFF
--- a/src/main/java/cmpt276/pg6/realtorest/controllers/FavoriteController.java
+++ b/src/main/java/cmpt276/pg6/realtorest/controllers/FavoriteController.java
@@ -25,7 +25,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
 @Controller
-public class FavouriteController {
+public class FavoriteController {
     @Autowired
     private UserRepository userRepo;
     @Autowired
@@ -50,8 +50,8 @@ public class FavouriteController {
         return request.getRequestURI();
     }
 
-    @GetMapping("/favourites")
-    public String showFavouritesPage(HttpServletRequest request, HttpSession session, Model model, HttpServletResponse response) {
+    @GetMapping("/favorites")
+    public String showFavoritesPage(HttpServletRequest request, HttpSession session, Model model, HttpServletResponse response) {
         // Set no-cache headers
         response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate"); // HTTP 1.1.
         response.setHeader("Pragma", "no-cache"); // HTTP 1.0.
@@ -64,27 +64,27 @@ public class FavouriteController {
             Optional<User> userOptional = userRepo.findById(userId);
             if (userOptional.isPresent()) {
                 User user = userOptional.get();
-                Set<Property> favouriteProperties = user.getFavouriteProperties();
-                model.addAttribute("favouriteProperties", favouriteProperties);
+                Set<Property> favoriteProperties = user.getFavoriteProperties();
+                model.addAttribute("favoriteProperties", favoriteProperties);
                 model.addAttribute("user", user); // Add this line
 
                 Map<Integer, List<Image>> propertyImages = new HashMap<>();
-                for (Property property : favouriteProperties) {
+                for (Property property : favoriteProperties) {
                     List<Image> images = imageRepo.findByPropertyID(property.getPid());
                     propertyImages.put(property.getPid(), images);
                 }
                 model.addAttribute("propertyImages", propertyImages); 
 
-                return "favourites";
+                return "favorites";
             }
         }
 
         return "redirect:/login";
     }
 
-    //Add property to favourites
-    @PostMapping("/add-favourite/{propertyId}")
-    public ResponseEntity<String> addToFavourites(@PathVariable Integer propertyId, HttpServletRequest request, HttpSession session) {
+    //Add property to favorites
+    @PostMapping("/add-favorite/{propertyId}")
+    public ResponseEntity<String> addToFavorites(@PathVariable Integer propertyId, HttpServletRequest request, HttpSession session) {
         User sessionUser = (User) session.getAttribute("session_user");
         Integer userId = sessionUser != null ? sessionUser.getUid() : null;
 
@@ -93,17 +93,17 @@ public class FavouriteController {
             Property property = propertyRepo.findById(propertyId).orElse(null);
 
             if (user != null && property != null) {
-                user.getFavouriteProperties().add(property);
+                user.getFavoriteProperties().add(property);
                 userRepo.save(user);
-                return ResponseEntity.ok("Property added to favourites successfully");
+                return ResponseEntity.ok("Property added to favorites successfully");
             }
         }
         return ResponseEntity.badRequest().body("User or Property not found");
     }
 
-    //Remove property from favourites
-    @DeleteMapping("/remove-favourite/{propertyId}")
-    public ResponseEntity<String> removeFromFavourites(@PathVariable Integer propertyId, HttpServletRequest request, HttpSession session) {
+    //Remove property from favorites
+    @DeleteMapping("/remove-favorite/{propertyId}")
+    public ResponseEntity<String> removeFromFavorites(@PathVariable Integer propertyId, HttpServletRequest request, HttpSession session) {
         User sessionUser = (User) session.getAttribute("session_user");
         Integer userId = sessionUser != null ? sessionUser.getUid() : null;
 
@@ -111,9 +111,9 @@ public class FavouriteController {
             Optional<User> userOptional = userRepo.findById(userId);
             if (userOptional.isPresent()) {
                 User user = userOptional.get();
-                user.getFavouriteProperties().removeIf(property -> property.getPid() == propertyId);
+                user.getFavoriteProperties().removeIf(property -> property.getPid() == propertyId);
                 userRepo.save(user);
-                return ResponseEntity.ok("Property removed from favourites successfully");
+                return ResponseEntity.ok("Property removed from favorites successfully");
             }
         }
         return ResponseEntity.badRequest().body("User not found");

--- a/src/main/java/cmpt276/pg6/realtorest/models/User.java
+++ b/src/main/java/cmpt276/pg6/realtorest/models/User.java
@@ -30,14 +30,14 @@ public class User {
     private boolean isOnMailingList;
     private String resetToken;
 
-    // Kevin: So it seems like, Malaika made the favourite list not as a attribute of users, but as a relationship table. Seems fine.
+    // Kevin: So it seems like, Malaika made the favorite list not as a attribute of users, but as a relationship table. Seems fine.
     @ManyToMany
     @JoinTable(
-        name = "user_favourite_properties",
+        name = "user_favorite_properties",
         joinColumns = @JoinColumn(name = "user_id"),
         inverseJoinColumns = @JoinColumn(name = "property_id"))
 
-    private Set<Property> favouriteProperties = new HashSet<>();
+    private Set<Property> favoriteProperties = new HashSet<>();
 
     public User() {}
 
@@ -120,11 +120,11 @@ public class User {
         this.resetToken = resetToken;
     }
 
-    public Set<Property> getFavouriteProperties() {
-        return favouriteProperties;
+    public Set<Property> getFavoriteProperties() {
+        return favoriteProperties;
     }
 
-    public void setFavouriteProperties(Set<Property> favouriteProperties) {
-        this.favouriteProperties = favouriteProperties;
+    public void setFavoriteProperties(Set<Property> favoriteProperties) {
+        this.favoriteProperties = favoriteProperties;
     }
 }

--- a/src/main/resources/static/css/propertyListing.css
+++ b/src/main/resources/static/css/propertyListing.css
@@ -266,23 +266,23 @@ body {
 .display-realtor .offcanvas-header .social-media a:hover {
     color: rgb(140, 140, 140);
 }
-.favourite-button {
+.favorite-button {
     padding-top: 15px;
     background-color: transparent;
     color: rgb(186, 186, 186);
     border: none;
     outline: none;
 }
-#favourite-button p {
+#favorite-button p {
     font-family: "Montserrat", sans-serif;
     color: rgb(100, 100, 100);
 }
-.favourite-button:hover {
+.favorite-button:hover {
     cursor: pointer;
     color: #f1c40f;
 }
 
-.favourite-button i.highlighted {
+.favorite-button i.highlighted {
     color: #f1c40f;
 }
 

--- a/src/main/resources/static/js/propertyListing.js
+++ b/src/main/resources/static/js/propertyListing.js
@@ -25,8 +25,8 @@ window.onload = function () {
             }
 
             // Initialize the state of favorite buttons based on local storage
-            var favouriteButtons = document.querySelectorAll(".favourite-button")
-            favouriteButtons.forEach(function (button) {
+            var favoriteButtons = document.querySelectorAll(".favorite-button")
+            favoriteButtons.forEach(function (button) {
                 var propertyId = button.getAttribute("data-pid")
                 if (localStorage.getItem(propertyId)) {
                     button.querySelector("i").classList.add("highlighted")
@@ -174,15 +174,15 @@ function updateFavoriteButtons() {
         .then((data) => {
             if (data.loggedIn) {
                 // User is logged in, update behavior of favorite buttons
-                var favoriteButtons = document.querySelectorAll(".favourite-button")
+                var favoriteButtons = document.querySelectorAll(".favorite-button")
                 favoriteButtons.forEach(function (button) {
                     button.onclick = function () {
-                        toggleFavourite(this)
+                        toggleFavorite(this)
                     }
                 })
             } else {
                 // User is not logged in, redirect to login page when any favorite button is clicked
-                var favoriteButtons = document.querySelectorAll(".favourite-button")
+                var favoriteButtons = document.querySelectorAll(".favorite-button")
                 favoriteButtons.forEach(function (button) {
                     button.onclick = function () {
                         window.location.href = "/login"
@@ -194,27 +194,27 @@ function updateFavoriteButtons() {
 }
 
 // Function to toggle favorite status
-function toggleFavourite(button) {
+function toggleFavorite(button) {
     var propertyId = button.getAttribute("data-pid")
     var iconElement = button.querySelector("i")
 
     if (iconElement.classList.contains("highlighted")) {
         // Remove from favorites
         iconElement.classList.remove("highlighted")
-        removeFavourite(propertyId)
+        removeFavorite(propertyId)
         localStorage.removeItem(propertyId) // Remove from local storage
     } else {
         // Add to favorites
         iconElement.classList.add("highlighted")
-        addFavourite(propertyId)
+        addFavorite(propertyId)
         localStorage.setItem(propertyId, true) // Add to local storage
     }
 }
 
 // Function to add property to favorites
-function addFavourite(propertyId) {
+function addFavorite(propertyId) {
     // Make AJAX POST request to add property to favorites
-    fetch(`/add-favourite/${propertyId}`, {
+    fetch(`/add-favorite/${propertyId}`, {
         method: "POST",
         credentials: "include", // This is required to include the session cookie in the request
     })
@@ -226,9 +226,9 @@ function addFavourite(propertyId) {
 }
 
 // Function to remove property from favorites
-function removeFavourite(propertyId) {
+function removeFavorite(propertyId) {
     // Make AJAX DELETE request to remove property from favorites
-    fetch(`/remove-favourite/${propertyId}`, {
+    fetch(`/remove-favorite/${propertyId}`, {
         method: "DELETE",
         credentials: "include", // This is required to include the session cookie in the request
     })

--- a/src/main/resources/templates/favorites.html
+++ b/src/main/resources/templates/favorites.html
@@ -10,14 +10,14 @@
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous" />
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous" defer></script>
         <link rel="stylesheet" href="css/propertyListing.css" />
-        <title>Favourite Properties</title>
+        <title>Favorite Properties</title>
     </head>
     <body class="property-listing">
         <!-- NAVIGATION BAR -->
         <div th:insert="~{fragments/navbar :: navbar}"></div>
 
         <section class="listing-container">
-            <section id="property-container" class="property-container" th:each="property : ${favouriteProperties}">
+            <section id="property-container" class="property-container" th:each="property : ${favoriteProperties}">
                 <!-- MODAL INFORMATION -->
                 <section class="modal fade" th:id="'modal' + ${property.pid}" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
                     <section class="modal-dialog modal-xl modal-dialog-scrollable">
@@ -41,9 +41,9 @@
                                 </section>
 
                                 <!-- PROPERTY INFO -->
-                                <section id="favourite-button" class="icon-subcontainer">
-                                    <button id="favourite-button-${property.pid}" class="favourite-button" th:data-pid="${property.pid}" onclick="toggleFavourite(this)"><i class="fa-solid fa-bookmark"></i></button>
-                                    <p>Add to favourites</p>
+                                <section id="favorite-button" class="icon-subcontainer">
+                                    <button id="favorite-button-${property.pid}" class="favorite-button" th:data-pid="${property.pid}" onclick="toggleFavorite(this)"><i class="fa-solid fa-bookmark"></i></button>
+                                    <p>Add to favorites</p>
                                 </section>
                                 <p class="location-address" th:text="${property.street + ', ' + property.city + ', ' + property.province +  ' ' + property.zipCode}"></p>
                                 <section class="location-icon-container">
@@ -128,26 +128,26 @@
         </section>
 
         <script>
-            function toggleFavourite(button) {
+            function toggleFavorite(button) {
                 var propertyId = button.getAttribute("data-pid")
                 var iconElement = button.querySelector("i")
 
                 if (iconElement.classList.contains("highlighted")) {
-                    // Remove from favourites
+                    // Remove from favorites
                     iconElement.classList.remove("highlighted")
-                    removeFavourite(propertyId)
+                    removeFavorite(propertyId)
                     localStorage.removeItem(propertyId) // Remove from local storage
                 } else {
-                    // Add to favourites
+                    // Add to favorites
                     iconElement.classList.add("highlighted")
-                    addFavourite(propertyId)
+                    addFavorite(propertyId)
                     localStorage.setItem(propertyId, true) // Add to local storage
                 }
             }
 
             window.onload = function () {
-                var favouriteButtons = document.querySelectorAll(".favourite-button")
-                favouriteButtons.forEach(function (button) {
+                var favoriteButtons = document.querySelectorAll(".favorite-button")
+                favoriteButtons.forEach(function (button) {
                     var propertyId = button.getAttribute("data-pid")
                     if (localStorage.getItem(propertyId)) {
                         button.querySelector("i").classList.add("highlighted")
@@ -155,21 +155,21 @@
                 })
             }
 
-            function viewFavourite() {
-                fetch("/favourites", {
+            function viewFavorite() {
+                fetch("/favorites", {
                     method: "GET",
                     credentials: "include", // This is required to include the session cookie in the request
                 })
                     .then((response) => response.json())
-                    .then((favouriteProperties) => {
-                        console.log(favouriteProperties)
+                    .then((favoriteProperties) => {
+                        console.log(favoriteProperties)
                     })
                     .catch((error) => console.error("Error:", error))
             }
 
-            function addFavourite(propertyId) {
-                // Make AJAX POST request to add property to favourites
-                fetch(`/add-favourite/${propertyId}`, {
+            function addFavorite(propertyId) {
+                // Make AJAX POST request to add property to favorites
+                fetch(`/add-favorite/${propertyId}`, {
                     method: "POST",
                     credentials: "include", // This is required to include the session cookie in the request
                 })
@@ -180,9 +180,9 @@
                     .catch((error) => console.error("Error:", error))
             }
 
-            function removeFavourite(propertyId) {
-                // Make AJAX DELETE request to remove property from favourites
-                fetch(`/remove-favourite/${propertyId}`, {
+            function removeFavorite(propertyId) {
+                // Make AJAX DELETE request to remove property from favorites
+                fetch(`/remove-favorite/${propertyId}`, {
                     method: "DELETE",
                     credentials: "include", // This is required to include the session cookie in the request
                 })

--- a/src/main/resources/templates/fragments/navbar.html
+++ b/src/main/resources/templates/fragments/navbar.html
@@ -36,13 +36,13 @@
             <a th:href="@{/mortgage}" class="navbar-category"><p>Mortgage Calculator</p></a>
 
             <!-- Check to see if the user signed in or not -->
-            <!-- If user is logged in, link to favourites page -->
+            <!-- If user is logged in, link to favorites page -->
             <th:block th:if="${user != null}">
-                <a th:href="@{/favourites}" class="navbar-category"><p>Favourites</p></a>
+                <a th:href="@{/favorites}" class="navbar-category"><p>Favorites</p></a>
             </th:block>
             <!-- If user is not logged in, link to login page -->
             <th:block th:if="${user == null}">
-                <a th:href="@{/login}" class="navbar-category"><p>Favourites</p></a>
+                <a th:href="@{/login}" class="navbar-category"><p>Favorites</p></a>
             </th:block>
 
             <!-- If the user is logged in then they are allowed to change their info-->

--- a/src/main/resources/templates/propertyListing.html
+++ b/src/main/resources/templates/propertyListing.html
@@ -95,11 +95,11 @@
                                 </section>
 
                                 <!-- PROPERTY INFO -->
-                                <section id="favourite-button" class="icon-subcontainer">
-                                    <button id="favourite-button-${property.pid}" class="favourite-button ${property.isFavourite ? 'highlighted' : ''}" th:data-pid="${property.pid}" onclick="toggleFavourite(this)">
+                                <section id="favorite-button" class="icon-subcontainer">
+                                    <button id="favorite-button-${property.pid}" class="favorite-button ${property.isFavorite ? 'highlighted' : ''}" th:data-pid="${property.pid}" onclick="toggleFavorite(this)">
                                         <i class="fa-solid fa-bookmark"></i>
                                     </button>
-                                    <p>Add to favourites</p>
+                                    <p>Add to favorites</p>
                                 </section>
                                 <p class="location-address" th:text="${property.street + ', ' + property.city + ', ' + property.province +  ' ' + property.zipCode}"></p>
                                 <section class="location-icon-container">

--- a/src/test/java/cmpt276/pg6/realtorest/controllers/ControllersTests.java
+++ b/src/test/java/cmpt276/pg6/realtorest/controllers/ControllersTests.java
@@ -126,7 +126,7 @@ public class ControllersTests {
     }
 
     @Test
-    public void testGetFavourites() {
+    public void testGetFavorites() {
         // Arrange
         HttpServletRequest request = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
@@ -138,19 +138,19 @@ public class ControllersTests {
         when(session.getAttribute("session_user")).thenReturn(user);
         when(userRepo.findById(1)).thenReturn(Optional.of(user));
 
-        FavouriteController favouriteController = new FavouriteController();
-        favouriteController.setUserRepo(userRepo);
+        FavoriteController favoriteController = new FavoriteController();
+        favoriteController.setUserRepo(userRepo);
 
-        String result = favouriteController.showFavouritesPage(request, session, model, response);
+        String result = favoriteController.showFavoritesPage(request, session, model, response);
 
         // Assert
-        assertEquals("favourites", result);
-        verify(model, times(1)).addAttribute(eq("favouriteProperties"), any(Set.class));
+        assertEquals("favorites", result);
+        verify(model, times(1)).addAttribute(eq("favoriteProperties"), any(Set.class));
         verify(model, times(1)).addAttribute("user", user);
     }
 
     @Test
-    public void testAddToFavourites() {
+    public void testAddToFavorites() {
         // Arrange
         HttpServletRequest request = mock(HttpServletRequest.class);
         HttpSession session = mock(HttpSession.class);
@@ -164,20 +164,20 @@ public class ControllersTests {
         when(userRepo.findById(1)).thenReturn(Optional.of(user));
         when(propertyRepo.findById(1)).thenReturn(Optional.of(property));
 
-        FavouriteController favouriteController = new FavouriteController();
-        favouriteController.setUserRepo(userRepo);
-        favouriteController.setPropertyRepo(propertyRepo); // set the propertyRepo mock
+        FavoriteController favoriteController = new FavoriteController();
+        favoriteController.setUserRepo(userRepo);
+        favoriteController.setPropertyRepo(propertyRepo); // set the propertyRepo mock
 
         // Act
-        ResponseEntity<String> result = favouriteController.addToFavourites(1, request, session);
+        ResponseEntity<String> result = favoriteController.addToFavorites(1, request, session);
 
         // Assert
-        assertEquals("Property added to favourites successfully", result.getBody());
+        assertEquals("Property added to favorites successfully", result.getBody());
         verify(userRepo, times(1)).save(user);
     }
 
     @Test
-    public void testRemoveFromFavourites() {
+    public void testRemoveFromFavorites() {
         // Arrange
         HttpServletRequest request = mock(HttpServletRequest.class);
         HttpSession session = mock(HttpSession.class);
@@ -187,19 +187,19 @@ public class ControllersTests {
         user.setUid(1);
         Property property = new Property();
         property.setPid(1);
-        user.getFavouriteProperties().add(property);
+        user.getFavoriteProperties().add(property);
         when(session.getAttribute("session_user")).thenReturn(user);
         when(userRepo.findById(1)).thenReturn(Optional.of(user));
 
-        FavouriteController favouriteController = new FavouriteController();
-        favouriteController.setUserRepo(userRepo);
-        favouriteController.setPropertyRepo(propertyRepo); // set the propertyRepo mock
+        FavoriteController favoriteController = new FavoriteController();
+        favoriteController.setUserRepo(userRepo);
+        favoriteController.setPropertyRepo(propertyRepo); // set the propertyRepo mock
 
         // Act
-        ResponseEntity<String> result = favouriteController.removeFromFavourites(1, request, session);
+        ResponseEntity<String> result = favoriteController.removeFromFavorites(1, request, session);
 
         // Assert
-        assertEquals("Property removed from favourites successfully", result.getBody());
+        assertEquals("Property removed from favorites successfully", result.getBody());
         verify(userRepo, times(1)).save(user);
     }
 


### PR DESCRIPTION
This change shouldn't break anything... but I have to admit, this is a pretty big change. I think I'm gonna need to write a justification for this.

But yeah, this is mostly for consistency. As in, for software developing, I think the standard is using American English for things. Changing it to "favorite" should make everything more consistent. This should also make things like Copilot behave slightly better, since there are more training data with the word "favorite".